### PR TITLE
Changing cryptmethod requires Vim 7.3 or later.

### DIFF
--- a/plugin/opinion.vim
+++ b/plugin/opinion.vim
@@ -83,7 +83,11 @@ set lazyredraw                  "lz:    will not redraw the screen while running
 "
 
 if has("cryptv")
-  set cryptmethod=blowfish        "cm:    make encryption more secure
+  if v:version > 704 || v:version == 704 && has("patch399")
+    set cryptmethod=blowfish2   "cm:    make encryption the most secure
+  elseif v:version >= 703
+    set cryptmethod=blowfish    "cm:    make encryption more secure than pkzip
+  endif
 endif
 
 "


### PR DESCRIPTION
Vim 7.2 will error with ``E518: Unknown option: cryptmethod=blowfish`` when using vim-opinion

Also we can use the blowfish2 variant when running Vim 7.4.399 or later.